### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/dotnet.test.yml
+++ b/.github/workflows/dotnet.test.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 


### PR DESCRIPTION
Adds an explicit permissions: contents: read block to workflows that lacked one (dotnet.test.yml), resolving the CodeQL actions/missing-workflow-permissions alert. These are read-only CI workflows.